### PR TITLE
Speed up the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,28 @@
-sudo: required
+sudo: false
 
 language: php
 php:
   - 7.1
 
+cache:
+  yarn: true
+  directories:
+    - $HOME/.composer/cache
+
 before_install:
-
   # Install melody
-
-  - sudo curl -Lo /usr/bin/melody http://get.sensiolabs.org/melody.phar
-  - sudo chmod +x /usr/bin/melody
+  - curl -Lo $HOME/bin/melody http://get.sensiolabs.org/melody.phar
+  - chmod +x $HOME/bin/melody
 
   # Retrieve documentation
-
   - bin/retrieve-documentation
 
   # Install dependencies
-
   - yarn install
 
 script:
-
   # Check CS
-
   - yarn lint
 
   # Check build
-
   - yarn gatsby build


### PR DESCRIPTION
- Cache Composer and Yarn dependencies
- Don't require `sudo`