### PR TITLE
Fix: Add footer on documentation pages on mobile

### DIFF
--- a/src/styles/objects/_container.scss
+++ b/src/styles/objects/_container.scss
@@ -38,6 +38,10 @@
 
   &.with-second-menu-displayed .footer {
     margin-left: $docmenuW;
+
+    @include mq($max-width: $vw-medium) {
+      margin-left: 0;
+    }
   }
 }
 


### PR DESCRIPTION
**Before**
![image](https://user-images.githubusercontent.com/966550/57172096-cb919980-6e1b-11e9-9014-226deb501860.png)


**After**
![image](https://user-images.githubusercontent.com/966550/57172091-b4eb4280-6e1b-11e9-88b9-045a725071f7.png)

