### PR TITLE
Feat: algolia search multi version in documentation

### DIFF
--- a/src/components/layout/Search.js
+++ b/src/components/layout/Search.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import scriptLoader from 'react-async-script-loader';
+import { currentVersion } from '../../../constants';
 
 class Search extends React.Component {
   componentWillReceiveProps({ isScriptLoaded, isScriptLoadSucceed }) {
@@ -27,6 +28,7 @@ class Search extends React.Component {
         indexName: process.env.GATSBY_DOCSEARCH_INDEX_NAME,
         inputSelector: this.searchInput,
         debug: false,
+        algoliaOptions: { facetFilters: [`version:v${currentVersion}`] }
       });
     }
   }


### PR DESCRIPTION
Updating the search configuration for the [API platform website](https://api-platform.com/).
  - The default search is only on the current version.
  - We would like to search by facet according to a version.

Pull request [Algolia configuration](https://github.com/algolia/docsearch-configs/pull/876)