### PR TITLE
Fix width bottom border of h2

### DIFF
--- a/src/styles/components/_docs.scss
+++ b/src/styles/components/_docs.scss
@@ -218,9 +218,9 @@
 
   h2 {
     font-size: 2.2rem;
-    margin: 5px 0 10px;
+    margin: 20px 0 0;
     border-bottom: 2px dotted $darkblue;
-    margin-top: 40px;
+    display: inline-block;
   }
 
   h3 {


### PR DESCRIPTION
Instead of splashing thousand words:

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/66002348-2ce19580-e4ac-11e9-8454-d9dc24e36a8e.png) |  ![image](https://user-images.githubusercontent.com/4408379/66002361-31a64980-e4ac-11e9-9981-33b07cd2c86a.png)|