### PR TITLE
Fix display SymfonyCasts player without caption

### DIFF
--- a/src/styles/components/_docs.scss
+++ b/src/styles/components/_docs.scss
@@ -171,6 +171,7 @@
   .symfonycasts {
     a {
       display: inline-block;
+      min-width: 350px;
     }
 
     .gatsby-resp-image-wrapper {


### PR DESCRIPTION
Closes #161 

Since we have not reached an agreement on inserting SC player via shortcode, I think it makes little sense to make this block markup more semantic, so this PR just fixes the bug found in issue above.

Sample page - https://api-platform.com/docs/core/

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/66598774-73b94480-ebaa-11e9-8cff-0bec1eb288f4.png) | ![image](https://user-images.githubusercontent.com/4408379/66598833-951a3080-ebaa-11e9-862b-16477d2aa213.png)  |

