### PR TITLE
Allow setting a different documentation repository

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DOC_REPOSITORY=https://github.com/api-platform/docs.git

--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DOC_REPOSITORY=https://github.com/api-platform/docs.git
+DOCS_REPOSITORY=https://github.com/api-platform/docs.git

--- a/bin/checkout-documentation
+++ b/bin/checkout-documentation
@@ -7,14 +7,14 @@ const path = require('path');
 const {docPagesDirectory, current, versions} = require('../constants');
 const versionHelper = require('../src/lib/versionHelper');
 
-const docRepository = process.env.DOC_REPOSITORY;
-console.info('\x1b[36m', `Using repository: ${docRepository}`, '\x1b[37m');
+const docsRepository = process.env.DOCS_REPOSITORY;
+console.info('\x1b[36m', `Using repository: ${docsRepository}`, '\x1b[37m');
 
 console.info('\x1b[36m', `Deleting ${docPagesDirectory}`, '\x1b[37m');
 execSync(`rm -rf ${docPagesDirectory}`);
 
 console.info('\x1b[36m', `Cloning the current version in ${docPagesDirectory}${current}`, '\x1b[37m');
-execSync(`git clone ${docRepository} ${docPagesDirectory}${current}`);
+execSync(`git clone ${docsRepository} ${docPagesDirectory}${current}`);
 console.info('\x1b[36m', 'Current version cloned', '\x1b[37m');
 
 const currentVersion = execSync(`git -C ${docPagesDirectory}${current} rev-parse --abbrev-ref HEAD`).toString().replace(/\n$/, '');

--- a/bin/checkout-documentation
+++ b/bin/checkout-documentation
@@ -1,16 +1,20 @@
 #!/usr/bin/env node
 
+require('dotenv').config();
 const {execSync} = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const {docPagesDirectory, current, versions} = require('../constants');
 const versionHelper = require('../src/lib/versionHelper');
 
+const docRepository = process.env.DOC_REPOSITORY;
+console.info('\x1b[36m', `Using repository: ${docRepository}`, '\x1b[37m');
+
 console.info('\x1b[36m', `Deleting ${docPagesDirectory}`, '\x1b[37m');
 execSync(`rm -rf ${docPagesDirectory}`);
 
 console.info('\x1b[36m', `Cloning the current version in ${docPagesDirectory}${current}`, '\x1b[37m');
-execSync(`git clone https://github.com/api-platform/docs.git ${docPagesDirectory}${current}`);
+execSync(`git clone ${docRepository} ${docPagesDirectory}${current}`);
 console.info('\x1b[36m', 'Current version cloned', '\x1b[37m');
 
 const currentVersion = execSync(`git -C ${docPagesDirectory}${current} rev-parse --abbrev-ref HEAD`).toString().replace(/\n$/, '');


### PR DESCRIPTION
This feature enables setting a different documentation repository with an optional environment variable, for development purposes.

Usage: 

```bash
$ DOCUMENTATION_REPOSITORY=https://github.com/bpolaszek/api-platform-docs ./bin/retrieve-documentation
```