### PR TITLE
Allow generation of sublevels

### DIFF
--- a/bin/generate-nav
+++ b/bin/generate-nav
@@ -7,6 +7,38 @@ const versionHelper = require('../src/lib/versionHelper');
 const {join, resolve} = require('path');
 const jsyaml = require('js-yaml');
 
+const createSublevels = (chapter, path) => {
+    const chapterPath = join(path, chapter.path);
+    const expectedFiles = chapter.items.filter(item => 'string' === typeof item);
+    const files = readdirSync(chapterPath)
+        .filter(file => file.endsWith('.md'))
+        .map(file => file.slice(0, -3));
+
+    // Check that all configured markdown files are actually here
+    expectedFiles.forEach(expectedFile => {
+        if (!files.includes(expectedFile)) {
+            throw Error(`${expectedFile} specified in outline.yaml but not found in ${chapterPath}.`);
+        }
+    });
+
+    // Check that all markdown files have been configured in outline.yaml
+    files.forEach(file => {
+        if (!expectedFiles.includes(file)) {
+            throw Error(`${file} not specified in outline.yaml in ${chapterPath}.`);
+        }
+    });
+
+    const items = [...chapter.items].map(item => {
+        if ('string' === typeof item) {
+            return fileProcessor.processFile(resolve(chapterPath), item)[0];
+        }
+        return createSublevels(item, chapterPath);
+    });
+
+    return {...chapter, items};
+};
+
+
 versions.push(current);
 versions.forEach(version => {
     const docs = { chapters: [] };
@@ -16,20 +48,7 @@ versions.forEach(version => {
     const loadedOutline = jsyaml.safeLoad(readFileSync(outlinePath, 'utf8'));
     const versionPath = join(docPagesDirectory, versionDirectory);
 
-    docs.chapters = loadedOutline.chapters.map(chapter => {
-        const chapterPath = join(versionPath, chapter.path);
-        const files = readdirSync(chapterPath)
-            .filter(file => file.endsWith('.md'))
-            .map(file => file.slice(0, -3));
-
-        chapter.items = chapter.items.filter(item => files.includes(item));
-
-        const items = [...new Set(chapter.items.concat(files))].map(file =>
-            fileProcessor.processFile(resolve(chapterPath), file)[0]
-        );
-
-        return { ...chapter, items };
-    });
+    docs.chapters = loadedOutline.chapters.map(chapter => createSublevels(chapter, versionPath));
 
     writeFile(resolve(join(versionPath, 'nav.yml')), jsyaml.safeDump(docs, { lineWidth: 255 }), error => error && console.warn(error));
 });


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | api-platform/docs#884
| License       | MIT
| Doc PR        | api-platform/docs#...

This PR allows parsing `outline.yaml` documentation files with nested items, allowing to organize the documentation with any number of sublevels. Example [here](https://github.com/bpolaszek/api-platform-docs/blob/2.5/outline.yaml).

Usage:
```bash
$ DOCS_REPOSITORY=https://github.com/bpolaszek/api-platform-docs ./bin/checkout-documentation
$ ./bin/generate-nav
$ yarn gatsby develop
```

It will clone [a fork of the doc](https://github.com/bpolaszek/api-platform-docs) with a nested documentation on the 2.5 (current) branch. 
You can then head to http://localhost:8000/docs/api-component/getting-started/.

The menu tree on the left of the UI will be broken on `current`, because the UI doesn't support nested levels at this time, but this is the purpose of another PR. Former documentation versions remain unaffected.