### PR TITLE
Update schema.js to fix the Swagger link

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -337,6 +337,7 @@ exports.createPages = async ({ graphql, actions }) => {
   // Redirect 301 old page
   createRedirect({ fromPath: '/news/', toPath: '/resources/news/', isPermanent: true, redirectInBrowser: true });
   createRedirect({ fromPath: '/support/', toPath: '/community/', isPermanent: true, redirectInBrowser: true });
+  createRedirect({ fromPath: '/docs/core/swagger/', toPath: '/docs/core/openapi/', isPermanent: true, redirectInBrowser: true });
 
   // Documentation pages
   const docPageTemplate = path.resolve('src/templates/doc.js');

--- a/src/data/schema.js
+++ b/src/data/schema.js
@@ -30,7 +30,7 @@ const schema = [
       },
       {
         icon: 'doc',
-        link: '/docs/core/swagger',
+        link: '/docs/core/openapi',
         title: 'Browse the Docs',
         text: 'Enjoy the beautiful, automatically generated, API documentation (Swagger/OpenAPI).',
       },


### PR DESCRIPTION
Fixing the link "https://api-platform.com/docs/core/swagger/" that leads to a 404