### PR TITLE
fix: safari flex issue on references

### DIFF
--- a/src/styles/components/home/_references.scss
+++ b/src/styles/components/home/_references.scss
@@ -49,6 +49,7 @@
 
   .references__item {
     display: flex;
+    align-items: center;
     &:not(.big) {
       @include grayscale-effect(0.5);
       padding: 15px;


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes<!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #... <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

Before fix : 
![image](https://user-images.githubusercontent.com/16579730/106478781-dc1beb80-64a9-11eb-8bf9-4cde40fde436.png)

After fix : 
![image](https://user-images.githubusercontent.com/16579730/106478804-e2aa6300-64a9-11eb-80d6-546055a3eabd.png)
