### PR TITLE
fix(speaker): wrong Mastodon link

### DIFF
--- a/src/con/data/2023/speakers/jerome-tanghe.md
+++ b/src/con/data/2023/speakers/jerome-tanghe.md
@@ -5,7 +5,7 @@ number: 100
 name: Jérôme Tanghe
 job: Senior Developer
 company: Les-Tilleuls.coop
-twitter: https://mastodon.online/@Deuchnord@mamot.fr
+twitter: https://mamot.fr/@Deuchnord
 github: https://github.com/Deuchnord
 ---
 


### PR DESCRIPTION
Fixing my Mastodon link that was using Mastodon.online instead of Mamot.fr.

I kept the link on the `twitter` parameter, because I don't know if there is a Mastodon-specific one.