### PR TITLE
fix: return true 404 when content missing

### DIFF
--- a/pwa/app/(common)/docs/[...slug]/page.tsx
+++ b/pwa/app/(common)/docs/[...slug]/page.tsx
@@ -59,6 +59,10 @@ export default async function Page({
     const { data, path } = await getDocContentFromSlug(version, slugs);
 
     const html = await getHtmlFromGithubContent(data, path, version);
+    if (html.includes("404: Not Found")) {
+      notFound();
+    }
+
     const title = await getDocTitle(version, slugs);
 
     const breadCrumbs = [

--- a/pwa/app/(common)/docs/guide/[slug]/page.tsx
+++ b/pwa/app/(common)/docs/guide/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import GuidePage from "./GuidePage";
 import { getAllDocLinks, getGuideContent } from "api/doc/guides";
+import { notFound } from "next/navigation";
 
 export async function generateStaticParams() {
   const guideLinks = await getAllDocLinks("guides");
@@ -26,6 +27,7 @@ export default async function Page({
       />
     );
   } catch (error) {
-    return <div>Error during loading page content</div>;
+    console.error(error);
+    notFound();
   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | staging
| License       | MIT

Return 404 when the content of GitHub response is “404: Not Found” instead of displaying it.