### PR TITLE
fix: use UK flag instead of US flag for British speakers

### DIFF
--- a/pwa/data/con/2024/conferences/artisinal-api-platform.md
+++ b/pwa/data/con/2024/conferences/artisinal-api-platform.md
@@ -9,7 +9,7 @@ short: Using API Platform with Laravel.
 tag: 'archi'
 ---
 
-# Artisinal API Platform (🇺🇸)
+# Artisinal API Platform (🇬🇧)
 
 Join me at the API Platform Conference for an insight into how to make the API Platform more "artisinal". By this, I mean we are going to explore how we can **use API Platform within a Laravel application**, and how we can lean on API Platform to craft robust APIs. We will delve into practical strategies, demonstrating how you can leverage the strengths of both frameworks to enhance your API development.
 

--- a/pwa/data/con/2024/conferences/better-debugging-with-xdebug.md
+++ b/pwa/data/con/2024/conferences/better-debugging-with-xdebug.md
@@ -9,7 +9,7 @@ short: How Xdebug helps you to be more productive.
 tag: 'good-practices'
 ---
 
-# Better Debugging with Xdebug (🇺🇸) 
+# Better Debugging with Xdebug (🇬🇧) 
 
 In this talk I explain how to use Xdebug to **get more productive writing PHP code**, focussing on the improvements in Xdebug 3.2 and 3.3, to make
 the debugging experience better and easier to set up.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | see https://phpc.social/@derickr/113078087166069126
| License       | MIT
| Doc PR        | 

API Platform Conference: fix the flag displayed on talks given by British speakers.