### PR TITLE
feat: getting-started steps for new api-platform CLI installer

### DIFF
--- a/pwa/app/(common)/components/timeline/TimelineLaravel.tsx
+++ b/pwa/app/(common)/components/timeline/TimelineLaravel.tsx
@@ -16,36 +16,35 @@ export default function TimelineLaravel() {
       <TimelineStepTitle step={1}>Install the framework</TimelineStepTitle>
       <StepContent className="pb-24">
         <p className="font-semibold text-blue text-2xl mb-4 leading-tight">
-          Installing Laravel
+          Scaffold a project
         </p>
-        <CodeBlock title="Install Laravel">
+        <CodeBlock title="Create a Laravel project">
           <InstallLaravelCode />
         </CodeBlock>
-        API Platform can be installed easily on new and existing Laravel
-        projects. If you already have an existing project, skip directly to the
-        next section.
+        This creates a new Laravel application with API Platform and a
+        ready-to-use React-admin interface. Already have a project?{" "}
+        <Link href="/docs/laravel/" prefetch={false} className="link">
+          Add API Platform to an existing Laravel app
+        </Link>{" "}
+        with{" "}
+        <code className="bg-gray-200 px-1 py-0.5 text-base dark:bg-blue-black">
+          composer require api-platform/laravel
+        </code>
+        .
       </StepContent>
       <StepContent>
         <p className="font-semibold text-blue text-2xl mb-4 leading-tight">
-          Installing API Platform
+          Run the app
         </p>
-        <CodeBlock title="Install API Platform">
+        <CodeBlock title="Start the development server">
           <InstallCode />
         </CodeBlock>
         <p>
-          In your Laravel project, install the API Platform integration for
-          Laravel.
+          Start the Vite dev server and the built-in PHP web server, then open
+          the admin.
         </p>
       </StepContent>
       <StepContent className="mt-24">
-        <p>
-          If it's not already done, run{" "}
-          <code className="bg-gray-200 px-1 py-0.5 text-base dark:bg-blue-black">
-            php artisan serve
-          </code>{" "}
-          to start the built-in web server.
-        </p>
-        <br />
         <p className="font-semibold text-blue text-2xl mb-4 leading-tight">
           Your development environment is ready!{" "}
         </p>

--- a/pwa/app/(common)/components/timeline/TimelinePhp.tsx
+++ b/pwa/app/(common)/components/timeline/TimelinePhp.tsx
@@ -19,6 +19,17 @@ export default function TimelineSymfony() {
         <CodeBlock title="Install">
           <InstallCode />
         </CodeBlock>
+        <p className="mt-6">
+          Starting a new project? Use the API Platform CLI to scaffold a full{" "}
+          <Link href="/?s=symfony" prefetch={false} className="link">
+            Symfony
+          </Link>{" "}
+          or{" "}
+          <Link href="/?s=laravel" prefetch={false} className="link">
+            Laravel
+          </Link>{" "}
+          application.
+        </p>
       </StepContent>
       <TimelineStepTitle step={2}>
         Define the resources

--- a/pwa/app/(common)/components/timeline/TimelineSymfony.tsx
+++ b/pwa/app/(common)/components/timeline/TimelineSymfony.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import InstallCode from "./symfony/Install.mdx";
+import PwaCode from "./symfony/Pwa.mdx";
 import ExposeCode from "./symfony/Expose.mdx";
 import PlugCode from "./symfony/Plug.mdx";
 import NativeCode from "./symfony/Native.mdx";
@@ -15,9 +16,13 @@ export default function TimelineSymfony() {
     <div className="relative dark:bg-blue-black">
       <TimelineStepTitle step={1}>Install the framework</TimelineStepTitle>
       <StepContent>
-        Install Docker and optionally GitHub CLI.
+        Install Docker, then scaffold a project with the API Platform CLI.
         <CodeBlock title="Install">
           <InstallCode />
+        </CodeBlock>
+        Start the Next.js Progressive Web App in another terminal:
+        <CodeBlock title="Start the PWA">
+          <PwaCode />
         </CodeBlock>
       </StepContent>
       <StepContent className="sm:mt-32">

--- a/pwa/app/(common)/components/timeline/laravel/InstallCode.mdx
+++ b/pwa/app/(common)/components/timeline/laravel/InstallCode.mdx
@@ -1,3 +1,5 @@
 ```bash
-composer require api-platform/laravel
+npm run dev          # in one terminal
+php artisan serve    # in another
+open http://localhost:8000/admin
 ```

--- a/pwa/app/(common)/components/timeline/laravel/InstallLaravelCode.mdx
+++ b/pwa/app/(common)/components/timeline/laravel/InstallLaravelCode.mdx
@@ -1,4 +1,7 @@
 ```bash
-composer create-project laravel/laravel my-api-platform-laravel-app
-cd my-api-platform-laravel-app
+# Install the api-platform CLI (detects your OS/arch)
+curl -fsSL https://api-platform.com/install.sh | sh
+# Scaffold a Laravel project with the React-admin frontend
+api-platform my-app --framework=laravel --with-admin
+cd my-app
 ```

--- a/pwa/app/(common)/components/timeline/symfony/Install.mdx
+++ b/pwa/app/(common)/components/timeline/symfony/Install.mdx
@@ -1,6 +1,9 @@
 ```bash
-gh repo create --clone --template api-platform/api-platform my-api --public # or --private
-cd my-api
-docker compose up
+# Install the api-platform CLI (detects your OS/arch)
+curl -fsSL https://api-platform.com/install.sh | sh
+# Scaffold the project (API + Next.js PWA, Docker)
+api-platform my-api --framework=symfony --with-docker --with-pwa
+cd my-api/api
+docker compose up --wait
 open https://localhost
 ```

--- a/pwa/app/(common)/components/timeline/symfony/Pwa.mdx
+++ b/pwa/app/(common)/components/timeline/symfony/Pwa.mdx
@@ -1,0 +1,5 @@
+```bash
+cd ../pwa
+pnpm dev
+open http://localhost:3000
+```


### PR DESCRIPTION
## What

Updates the homepage **Getting Started** timeline to use the new `api-platform` CLI installer ([api-platform/api-platform#2980](https://github.com/api-platform/api-platform/pull/2980)), replacing the old `gh repo create --template` distribution flow.

## Changes

- **Symfony** (`?s=symfony`): `curl -fsSL https://api-platform.com/install.sh | sh` then `api-platform my-api --framework=symfony --with-docker --with-pwa`; added a PWA frontend block (`cd ../pwa && pnpm dev`).
- **Laravel** (`?s=laravel`): scaffold with `api-platform my-app --framework=laravel --with-admin`; restructured into **Scaffold a project** / **Run the app** steps. Kept a note pointing existing-project users to `composer require api-platform/laravel`.
- **PHP** (default): kept `composer require api-platform/core` (the documented framework-agnostic entry — granular components have no getting-started docs path); added a pointer to the CLI for scaffolding full Symfony/Laravel apps.

## Depends on

- [ ] website #674 — `pwa/public/install.sh` served at `api-platform.com/install.sh` (default install dir already `~/.local/bin`).
- [ ] api-platform/api-platform#2980 — a published `v*` release with the four binaries + `.sha256`.

Until both ship the one-liner 404s, so **land this last**.

## Verify

`cd pwa && pnpm install && pnpm dev`, then check `/?s=symfony`, `/?s=laravel`, and `/` (PHP) render the new commands and copy buttons work; `pnpm build` passes.