### PR TITLE
fix(docker): bump PHP to 8.4 for Symfony 8 / API Platform 4.3

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,7 @@
 
 
 # Versions
-FROM php:8.2-fpm-alpine AS php_upstream
+FROM php:8.4-fpm-alpine AS php_upstream
 FROM mlocati/php-extension-installer:2 AS php_extension_installer_upstream
 FROM composer/composer:2-bin AS composer_upstream
 FROM caddy:2-alpine AS caddy_upstream


### PR DESCRIPTION
## Problem

CD build fails after #677 (Symfony 8 / API Platform 4.3 upgrade):

```
symfony/yaml v8.1.0 requires php >=8.4.1 -> your php version (8.2.31) does not satisfy that requirement.
```

`composer.json` was bumped to `>=8.4` and `composer.lock` pins Symfony 8 packages (require php >=8.4.1), but `api/Dockerfile` still used `php:8.2-fpm-alpine`.

## Fix

Bump base image `php:8.2-fpm-alpine` -> `php:8.4-fpm-alpine`.

Helm checked: no PHP version refs (images injected at deploy).