### PR TITLE
feat: advertise API Platform skillset (help page + footer)

### DIFF
--- a/pwa/app/(common)/help/page.tsx
+++ b/pwa/app/(common)/help/page.tsx
@@ -170,6 +170,33 @@ export default async function Page() {
           />
         </div>
       </div>
+      <div>
+        <div className="container xl:max-w-5xl flex flew-row items-center relative gap-16 py-12">
+          <div className="flex-1 max-w-2xl py-6 mx-auto text-center">
+            <Heading size="lg" level="h2" overline="AI coding agents">
+              Teach AI agents the <strong>canonical way</strong>
+            </Heading>
+            <p className="mt-4">
+              The API Platform Skillset teaches AI coding agents the canonical
+              API Platform 4.x way, with 15 skills covering both Symfony and
+              Laravel. Install the Claude Code plugin to keep your agents
+              aligned with framework best practices.
+            </p>
+            <div className="mt-6 flex flex-wrap justify-center gap-4">
+              <Button
+                external
+                href="https://github.com/api-platform/skillset"
+                size="medium"
+              >
+                Get the skillset
+              </Button>
+              <Button href="/docs/core/ai-agents" size="medium" empty>
+                Learn more
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
       <div className="bg-blue-extralight/50 dark:bg-blue-dark dark:text-white after:absolute after:w-full after:h-80 after:top-full after:left-0 after:bg-blue-extralight/50 after:dark:bg-blue-dark">
         <div className="container xl:max-w-5xl flex flew-row items-center relative gap-16 pt-12">
           <img

--- a/pwa/data/footer.ts
+++ b/pwa/data/footer.ts
@@ -31,6 +31,10 @@ const footer: FooterPart[] = [
         url: "https://symfonycasts.com/screencast/api-platform?cid=apip",
       },
       {
+        title: "AI coding-agent skills",
+        url: "/docs/core/ai-agents/",
+      },
+      {
         title: "Stack Overflow",
         url: "https://stackoverflow.com/questions/tagged/api-platform.com",
       },


### PR DESCRIPTION
Advertises the [API Platform skillset](https://github.com/api-platform/skillset) — AI coding-agent skills for Claude Code — as a developer resource.

## Changes
- **`/help` page**: a new "AI coding agents" band (before Screencasts), reusing the existing `Heading`+`Button` primitives. Primary button → the skillset repo; secondary → the docs page `/docs/core/ai-agents`.
- **Footer**: a link in the existing **Help** group → `/docs/core/ai-agents/`, following the group's object shape.

Chosen over the footer "Resources" group (logos/wallpapers — brand assets only, no listing page) because `/help` is the established home for developer-facing learning resources (Screencasts, Stack Overflow, Slack) and the skillset is a direct sibling. No new components; `tsc --noEmit` clean.

Companion docs PR adds `/docs/core/ai-agents`.